### PR TITLE
Padding to margin in first children

### DIFF
--- a/lib/src/sass/_typography.scss
+++ b/lib/src/sass/_typography.scss
@@ -134,11 +134,11 @@ article ul > li:before {
 }
 
 article ul > li:first-child, article ol > li:first-child {
-    padding-top: 6px;
+    margin-top: 6px !important;
 }
 
 article ul > li:last-child, article ol > li:last-child {
-    padding-bottom: 6px;
+    margin-bottom: 6px !important;
 }
 
 article ol > li {
@@ -159,11 +159,11 @@ article ul li ul li:before {
 }
 
 article ul li ul li:first-child, article ol li ol li:first-child {
-    padding-top: 6px;
+    margin-top: 6px !important;
 }
 
 article ul li ul li:last-child, article ol li ol li:last-child {
-    padding-bottom: 6px;
+    margin-bottom: 6px !important;
 }
 
 article ol > li > ol > li {
@@ -180,11 +180,11 @@ article ul li ul li ul li:before {
 }
 
 article ul li ul li ul li:first-child, article ol li ol li ol li:first-child {
-    padding-top: 6px;
+    margin-top: 6px !important;
 }
 
 article ul li ul li ul li:last-child, article ol li ol li ol li:last-child {
-    padding-bottom: 6px;
+    margin-bottom: 6px !important;
 }
 
 article ol li ol li ol li {


### PR DESCRIPTION
This was a tough one!  Padding is whitespace applied inside the element, margin is whitespace outside the element.  I _think_ what was going on here was that in the ul, the padding was getting applied inside the table they were wrapped in, and wasn't making it out.  The ol elements weren't inside a table so it wasn't an issue.

Btw - I really like your formatting change to put the two lists into tables side by side.  I'm assuming you'll get rid of the versions above the table right?  Probably don't need them both.